### PR TITLE
220419 이미지 출력 안되는 것들 수정, 상품 상세-> 관심상품 등록, 장바구니랑 주문 오류수정

### DIFF
--- a/ecorea/src/main/java/com/project/ecorea/controller/mvc/BookmarkMvcController.java
+++ b/ecorea/src/main/java/com/project/ecorea/controller/mvc/BookmarkMvcController.java
@@ -22,40 +22,42 @@ public class BookmarkMvcController {
 	// 관심상품 목록 출력
 	@GetMapping("/mypage/member/bookmarkList")
 	public ModelAndView readBookmark(Principal principal) {
-		String memberId = principal.getName();
-		List<BookmarkDto.BookmarkList> bookmarkList = bookmarkService.readBookmark(memberId);
+		List<BookmarkDto.BookmarkList> bookmarkList = bookmarkService.readBookmark(principal.getName());
 		return new ModelAndView("mypage/member/bookmarkList").addObject("bookmarkList", bookmarkList);		
 	}
 	
 	// 관심상품 한개 삭제
 	@PostMapping("/mypage/member/bookmarkList/deleteOne")
 	public String deleteOne(Integer pno, Principal principal) {
-		String memberId = principal.getName();
-		bookmarkService.deleteOne(memberId, pno);
+		bookmarkService.deleteOne(principal.getName(), pno);
 		return "redirect:/mypage/member/bookmarkList";
 	}
 
 	// 관심상품 전체 삭제 
 	@PostMapping("/mypage/member/bookmarkList/deleteAll")
 	public String deleteAll(Principal principal) {
-		String memberId = principal.getName();
-		bookmarkService.deleteAll(memberId);
+		bookmarkService.deleteAll(principal.getName());
 		return "redirect:/mypage/member/bookmarkList";
 	}
 	
 	// 관심상품 선택 삭제
 	@PostMapping("/mypage/member/bookmarkList/deleteSelected")
 	public String deleteSelected(BookmarkDto.PnoSelected dto, Principal principal) {
-		String memberId = principal.getName();
-		bookmarkService.deleteSelected(memberId, dto);
+		bookmarkService.deleteSelected(principal.getName(), dto);
 		return "redirect:/mypage/member/bookmarkList";
 	}
 	
 	// 관심상품 한 개 장바구니에 담기
 	@PostMapping("/mypage/member/bookmarkList/shoppingOne")
 	public String shoppingCartOne(Integer pno, Principal principal) {		
-		String memberId = principal.getName();
-		productService.shoppingCartOne(pno, memberId);	
+		productService.shoppingCartOne(pno, principal.getName());	
 		return "redirect:/order/cart";
-	}	
+	}
+	
+	// 상품상세 -> 관심상품 등록
+	@PostMapping("/bookmark/add")
+	public String addBookmark(Integer pno, Principal principal) {
+		bookmarkService.addBookmark(pno, principal.getName());
+		return "redirect:/mypage/member/bookmarkList";
+	}
 }

--- a/ecorea/src/main/java/com/project/ecorea/dao/BookmarkDao.java
+++ b/ecorea/src/main/java/com/project/ecorea/dao/BookmarkDao.java
@@ -10,7 +10,7 @@ import com.project.ecorea.dto.*;
 public interface BookmarkDao {
 	
 	// 관심상품 리스트 출력
-	public List<BookmarkDto.BookmarkList> findByMemberId(String memberId);
+	public List<BookmarkDto.BookmarkList> findByMemberId(String memberId, String imagePath);
 	
 	// 관심상품 한 개 삭제
 	public Integer deleteOne(String memberId, Integer pno);
@@ -20,5 +20,8 @@ public interface BookmarkDao {
 	
 	// 관심상품 선택 삭제
 	public Integer deleteSelected(String memberId, List<Integer> pnos);
+
+	// 관심상품 등록
+	public Integer saveBookmark(Integer pno, String memberId);
 	
 }

--- a/ecorea/src/main/java/com/project/ecorea/dao/CartDao.java
+++ b/ecorea/src/main/java/com/project/ecorea/dao/CartDao.java
@@ -12,7 +12,7 @@ public interface CartDao {
 	
 	public Cart findByMemberIdAndPno(String memberId, Integer pno); 
 	
-	public List<CartDto.CartList> findByMemberId(String memberId);
+	public List<CartDto.CartList> findByMemberId(String memberId, String imagePath);
 	
 	public Integer updateCntPlus(Cart cart);
 	

--- a/ecorea/src/main/java/com/project/ecorea/service/BookmarkService.java
+++ b/ecorea/src/main/java/com/project/ecorea/service/BookmarkService.java
@@ -2,22 +2,25 @@ package com.project.ecorea.service;
 
 import java.util.*;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.*;
 
 import com.project.ecorea.dao.*;
 import com.project.ecorea.dto.*;
-import com.project.ecorea.entity.*;
 
 import lombok.*;
 
 @Service
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class BookmarkService {
-	private BookmarkDao bookmarkDao;
+	@Value("${upload.image.path}")
+	private String imagePath;
+	
+	private final BookmarkDao bookmarkDao;
 	
 	// 관심상품 리스트 출력
 	public List<BookmarkDto.BookmarkList> readBookmark(String memberId) {
-		List<BookmarkDto.BookmarkList> list = bookmarkDao.findByMemberId(memberId);
+		List<BookmarkDto.BookmarkList> list = bookmarkDao.findByMemberId(memberId, imagePath);
 		return list;
 	}
 	
@@ -43,6 +46,15 @@ public class BookmarkService {
 		Integer deleteSelectedResult = bookmarkDao.deleteSelected(memberId, dto.getPnos());
 		if(deleteSelectedResult<=0)
 			return false;
+		return true;
+	}
+
+	// 상품상세 -> 관심상품 등록
+	public Boolean addBookmark(Integer pno, String memberId) {
+		Integer result = bookmarkDao.saveBookmark(pno, memberId);
+		if(result<=0) {
+			return false;
+		}
 		return true;
 	}
 	

--- a/ecorea/src/main/java/com/project/ecorea/service/CartService.java
+++ b/ecorea/src/main/java/com/project/ecorea/service/CartService.java
@@ -3,6 +3,7 @@ package com.project.ecorea.service;
 
 import java.util.*;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.*;
 
 import com.project.ecorea.dao.*;
@@ -11,16 +12,18 @@ import com.project.ecorea.entity.*;
 
 import lombok.*;
 
-@AllArgsConstructor
+@RequiredArgsConstructor
 @Service
 public class CartService {
+	@Value("${upload.image.path}")
+	private String imagePath;
 	
-	private CartDao cartDao;
-	private ProductDao productDao;
+	private final CartDao cartDao;
+	private final ProductDao productDao;
 	
 	// 장바구니 목록 출력
 	public List<CartDto.CartList> readCart(String memberId) {
-		return cartDao.findByMemberId(memberId);
+		return cartDao.findByMemberId(memberId, imagePath);
 	}
 	
 	// 상품 갯수 증가
@@ -58,7 +61,9 @@ public class CartService {
 	
 	// 선택상품 삭제
 	public Integer deleteSelected(String memberId, CartDto.DeleteSelected dto) {
-		Integer deleteSelectedResult = cartDao.deleteSelected(memberId, dto.getPnos());
+		List<Integer> list = dto.getPnos();
+		list.removeAll(Collections.singleton(null));
+		Integer deleteSelectedResult = cartDao.deleteSelected(memberId, list);			
 		return deleteSelectedResult;		
 	}
 }

--- a/ecorea/src/main/java/com/project/ecorea/service/JumunService.java
+++ b/ecorea/src/main/java/com/project/ecorea/service/JumunService.java
@@ -29,10 +29,11 @@ public class JumunService {
 	/* 상품 -> 바로 구매 */
 	public JumunDto.JumunPreview jumunOne(Integer pno, Integer count, String memberId) {
 		Product product = productDao.findByPno(pno);
+		product.setPthumbnail(imagePath+product.getPthumbnail());
 		System.out.println(product);
 		List<CartDto.CartProduct> products = new ArrayList<>();
 		Integer totalPrice = product.getPrice() * count;
-		products.add(new CartProduct(pno, product.getPname(), count, totalPrice, memberId));
+		products.add(new CartProduct(pno, product.getPname(), count, totalPrice, product.getPthumbnail()));
 		Member member = memberDao.memberFindById(memberId);
 		JumunDto.JumunPreview jumunPreview = new JumunPreview(products, member.getPoint(), totalPrice, member.getName(), member.getEmail());
 		return jumunPreview;
@@ -47,7 +48,7 @@ public class JumunService {
 				Product product = productDao.findByPno(param.getPno());
 				if(param.getCnt()<=product.getPstock()) {
 					CartDto.CartProduct jumunProduct = CartProduct.builder().pno(param.getPno()).cartpname(product.getPname())
-							.pthumbnail(product.getPthumbnail()).cartcnt(param.getCnt()).price(product.getPrice()).build();
+							.pthumbnail(imagePath+product.getPthumbnail()).cartcnt(param.getCnt()).price(product.getPrice()).build();
 					totalPrice = totalPrice + (product.getPrice()*param.getCnt());
 					products.add(jumunProduct);
 				}				

--- a/ecorea/src/main/resources/mybatis-mapper/bookmarkMapper.xml
+++ b/ecorea/src/main/resources/mybatis-mapper/bookmarkMapper.xml
@@ -3,7 +3,7 @@
 <mapper namespace="com.project.ecorea.dao.BookmarkDao">
 	<!-- 관심상품 list 출력 -->
 	<select id="findByMemberId" resultType="com.project.ecorea.dto.BookmarkDto$BookmarkList">
-		select p.pno, p.catecode, p.pname, p.price, p.pthumbnail
+		select p.pno, p.catecode, p.pname, p.price, #{imagePath} || p.pthumbnail as pthumbnail
 		from bookmark b 
 			left join product p
 		on b.pno=p.pno
@@ -25,5 +25,10 @@
 		<foreach collection="pnos" item="pno" open="(" separator="," close=")">
 			#{pno}
 		</foreach>
-	</delete>	
+	</delete>
+	
+	<!-- 관심상품 등록 -->
+	<insert id="saveBookmark">
+		insert into bookmark values(#{memberId}, #{pno})
+	</insert>	
 </mapper>

--- a/ecorea/src/main/resources/mybatis-mapper/cartMapper.xml
+++ b/ecorea/src/main/resources/mybatis-mapper/cartMapper.xml
@@ -16,7 +16,7 @@
 	</resultMap>
 
 	<select id="findByMemberId" resultMap="mapForCartList">
-		select c.pno, c.cartcnt, p.price, p.pname, p.pthumbnail, e.corp_name 
+		select c.pno, c.cartcnt, p.price, p.pname, #{imagePath} || p.pthumbnail as pthumbnail, e.corp_name 
 		from cart c 
     		inner join product p 
         		on(c.pno=p.pno)

--- a/ecorea/src/main/resources/templates/mypage/member/bookmarkList.html
+++ b/ecorea/src/main/resources/templates/mypage/member/bookmarkList.html
@@ -91,7 +91,9 @@
       				<span th:text="${list.pno}"></span>
       			</div>
       		</td>
-            <td th:text="${list.pthumbnail}"></td>
+            <td>
+            	<img alt="상품 이미지" th:src="${list.pthumbnail}">
+            </td>
             <td th:text="${list.pname}"></td>
             <td th:text="${list.price}"></td>
             <td>

--- a/ecorea/src/main/resources/templates/mypage/member/newAddress.html
+++ b/ecorea/src/main/resources/templates/mypage/member/newAddress.html
@@ -46,7 +46,6 @@
               atel : $('#totel').val(),
               atoname : $('#toperson').val(),
               astandard : 0,
-              member_id : "zzzzuny"
            }
            $.ajax({
               url: "/mypage/member/addAddressRest",

--- a/ecorea/src/main/resources/templates/order/cart.html
+++ b/ecorea/src/main/resources/templates/order/cart.html
@@ -105,7 +105,7 @@
 			if(result==true) {
 				const $form = $('<form>').attr('method','post').attr('action','/order/cart/deleteSelected').appendTo($('body'));
 				$('<input>').attr('type','hidden').attr('name','confirm').val("confirm").appendTo($form);
-				$('.pno').each(function(idx, checkbox) {
+				$('.check_pno').each(function(idx, checkbox) {
 					if($(this).prop('checked')==true) {
 						$('<input>').attr('type','hidden').attr('name','pnos').val($(this).attr('data-pno')).appendTo($form);
 					}
@@ -122,9 +122,9 @@
 			if(result == true) {
 				const $form = $('<form>').attr('method','post').attr('action','/order/preview/multiple').appendTo($('body')); 
 				$('.check_pno').each(function(idx, checkbox) {
-					if($(checkbox).prop('checked')==true) {
-						const pno = parseInt($(checkbox).attr('data-pno'));
-						const count = parseInt($(checkbox).parent().parent().next().next().next().find(".cartcnt").text());
+					if($(this).prop('checked')==true) {
+						const pno = parseInt($(this).attr('data-pno'));
+						const count = parseInt($(this).parent().parent().next().next().next().find(".cartcnt").text());
 						$('<input>').attr('type','hidden').attr('name','paramsList['+ idx + '].pno').val(pno).appendTo($form);
 						$('<input>').attr('type','hidden').attr('name','paramsList['+ idx + '].cnt').val(count).appendTo($form);
 					}
@@ -171,11 +171,13 @@
                         <tr th:each="product: ${list.cartProduct}">
                             <td>
                                 <div class="form-check">
-                                    <input type="checkbox" class="form-check-input check_pno" th:data-pno="${product.pno}" value="">
+                                    <input type="checkbox" class="form-check-input check_pno" th:data-pno="${product.pno}">
                                     <span>&nbsp;&nbsp;<span th:text="${product.pno}" name="pno" id="pno"></span></span>                                    
                                 </div>
                             </td>
-                            <td th:text="${product.pthumbnail}"></td> 
+                            <td>
+                            	<img th:src="${product.pthumbnail}" width="200">
+                            </td> 
                             <td>
                                 <span name="cartpname" id="cartpname" th:text="${product.cartpname}"></span>
                                 <span>(&nbsp;<span name="price" id="price" th:text="${product.price}"></span>&nbsp;)</span>

--- a/ecorea/src/main/resources/templates/order/pay.html
+++ b/ecorea/src/main/resources/templates/order/pay.html
@@ -34,7 +34,9 @@
     function printAddresses() {
     	$.ajax("/mypage/member/addressListRest").done(list=>{
     		if(list=="") {
-    			$("#address_msg").text("등록된 배송지가 없습니다. 배송지를 등록하세요.");
+    			$("#address_area").empty();
+    			$('<button type="button" class="btn btn-primary">').attr("id","add_new_address").text("새 배송지").appendTo($("#address_area"));
+    			$("<span>").text("등록된 배송지가 없습니다. 배송지를 등록하세요.").css("color","red").appendTo("#address_area");
     			$('#order').prop("disabled",true);
     		} else {
     			$("#address_area").empty();
@@ -130,7 +132,7 @@
   		
   		$("#address_area").on("click", "#add_new_address", function() {
   			const popup = window.open("/mypage/member/newAddress","_blank","toolbar=yes, menubar=yes, width=700, height=500");
-  			$(popup).on("beforeunload", printAddresses);
+  			$(popup).on("beforeunload", $('#order').prop("disabled",false), printAddresses);
   		});
   		
   		$("#address_area").on("click", ".radio_adr", changeAddress);
@@ -159,7 +161,9 @@
                         </thead>
                         <tbody>
                             <tr th:each="product: ${preview.products}">
-                                <td th:text="${product.pthumbnail}"></td>
+                                <td>
+                                	<img th:src="${product.pthumbnail}" width="100">
+                                </td>
                                 <td th:text="${product.cartpname}"></td>
                                 <td th:text="${product.cartcnt}"></td>
                                 <td th:text="${product.price*product.cartcnt}" id="cartPrice"></td>

--- a/ecorea/src/main/resources/templates/product/member/productDetail.html
+++ b/ecorea/src/main/resources/templates/product/member/productDetail.html
@@ -74,6 +74,16 @@
   		}
   	}
   	
+  	/* 관심상품 등록 버튼 */
+  	function toBookmark() {
+  		const check = confirm("관심상품으로 등록했습니다. 관심상품으로 이동하시겠습니까?");
+  		if(check == true) {
+  			const $form = $('<form>').attr('method','post').attr('action', '/bookmark/add').appendTo($('body'));
+  			$("<input>").attr("type","hidden").attr("name","pno").val(product.pno).appendTo($form);
+  			$form.submit();
+  		}
+  	}
+  	
 	/* 페이지 정보 */
   	const cri = {
 		pno : product.pno,
@@ -235,6 +245,7 @@
   	  $('#minus').click(minusCnt);
   	  $('#order').click(toOrder);
   	  $('#cart').click(toCart);
+  	  $('#bookmark').click(toBookmark);
  		
       const pno = product.pno;
       
@@ -332,7 +343,7 @@
       <span>총 합계 : </span><span><span id='totalPrice' th:text="${product.price}"></span>&nbsp;원</span><span> (<span id='totalCnt'>1</span>&nbsp;개)</span><br><br>
       <button type="button" class="btn btn-primary" id="order" value="바로구매">바로구매</button>
       <button type="button" class="btn btn-primary" id="cart" value="장바구니 담기">장바구니 담기</button>
-      <button type="button" class="btn btn-primary" value="관심상품 등록" formaction="#">관심상품 등록</button>
+      <button type="button" class="btn btn-primary" id="bookmark" value="관심상품 등록">관심상품 등록</button>
     </div>
 
       <div class="inside-product topnav topnav-right">

--- a/ecorea/src/test/java/com/project/ecorea/BookmarkTest.java
+++ b/ecorea/src/test/java/com/project/ecorea/BookmarkTest.java
@@ -46,12 +46,20 @@ public class BookmarkTest {
 	}
 	
 	@Transactional
-	@Test
+	//@Test
 	public void deleteSelectedTest() {
 		String memberId = "zzzzuny";
 		List<Integer> pnos = new ArrayList<>(Arrays.asList(1,3));
 		Integer result = bookmarkDao.deleteSelected(memberId, pnos);
 		assertEquals(result, 2);
 		
+	}
+	
+	@Transactional
+	@Test
+	public void saveTest() {
+		String memberId = "spring11";
+		Integer result = bookmarkDao.saveBookmark(1, memberId);
+		assertEquals(result, 1);
 	}
 }

--- a/ecorea/src/test/java/com/project/ecorea/CartTest.java
+++ b/ecorea/src/test/java/com/project/ecorea/CartTest.java
@@ -33,7 +33,8 @@ public class CartTest {
 	//@Test
 	public void readCartServiceTest() {
 		String memberId = "zzzzuny";
-		List<CartDto.CartList> cartList = cartDao.findByMemberId(memberId);
+		String imagePath = "/images/";
+		List<CartDto.CartList> cartList = cartDao.findByMemberId(memberId, imagePath);
 		System.out.println("==============================");
 		System.out.println("cartList : " + cartList);
 		System.out.println("==============================");


### PR DESCRIPTION
## 220419
1. 이미지 출력 안되는 것들 수정
    - 상품 list -> 바로구매 이동시
    - 장바구니 list 
2. 배송지 list가 없을 때 주문버튼 비활성화
    -> 배송지 추가하면 활성화 되도록
3. 장바구니에서 선택삭제 오류 수정
4. 상품 상세페이지 -> 관심상품 등록